### PR TITLE
Fix some errors picked up by Coverity Scan.

### DIFF
--- a/src/kernel_chameleon_decode.c
+++ b/src/kernel_chameleon_decode.c
@@ -70,7 +70,7 @@ DENSITY_FORCE_INLINE DENSITY_KERNEL_DECODE_STATE density_chameleon_decode_check_
                 density_byte resetDictionaryCycleShift = state->parameters.as_bytes[0];
                 if (resetDictionaryCycleShift) {
                     density_chameleon_dictionary_reset(&state->dictionary);
-                    state->resetCycle = (uint_fast64_t)(1 << resetDictionaryCycleShift) - 1;
+                    state->resetCycle = ((uint_fast64_t) 1 << resetDictionaryCycleShift) - 1;
                 }
             }
 
@@ -141,7 +141,7 @@ DENSITY_WINDOWS_EXPORT DENSITY_FORCE_INLINE DENSITY_KERNEL_DECODE_STATE density_
     state->parameters = parameters;
     density_byte resetDictionaryCycleShift = state->parameters.as_bytes[0];
     if (resetDictionaryCycleShift)
-        state->resetCycle = (uint_fast64_t)(1 << resetDictionaryCycleShift) - 1;
+        state->resetCycle = ((uint_fast64_t) 1 << resetDictionaryCycleShift) - 1;
 
     state->endDataOverhead = endDataOverhead;
 

--- a/src/kernel_cheetah_decode.c
+++ b/src/kernel_cheetah_decode.c
@@ -71,7 +71,7 @@ DENSITY_FORCE_INLINE DENSITY_KERNEL_DECODE_STATE density_cheetah_decode_check_st
                 density_byte resetDictionaryCycleShift = state->parameters.as_bytes[0];
                 if (resetDictionaryCycleShift) {
                     density_cheetah_dictionary_reset(&state->dictionary);
-                    state->resetCycle = (uint_fast64_t) (1 << resetDictionaryCycleShift) - 1;
+                    state->resetCycle = ((uint_fast64_t) 1 << resetDictionaryCycleShift) - 1;
                 }
             }
 
@@ -179,7 +179,7 @@ DENSITY_WINDOWS_EXPORT DENSITY_FORCE_INLINE DENSITY_KERNEL_DECODE_STATE density_
     state->parameters = parameters;
     density_byte resetDictionaryCycleShift = state->parameters.as_bytes[0];
     if (resetDictionaryCycleShift)
-        state->resetCycle = (uint_fast64_t) (1 << resetDictionaryCycleShift) - 1;
+        state->resetCycle = ((uint_fast64_t) 1 << resetDictionaryCycleShift) - 1;
 
     state->endDataOverhead = endDataOverhead;
 

--- a/src/kernel_lion_decode.c
+++ b/src/kernel_lion_decode.c
@@ -296,7 +296,7 @@ DENSITY_WINDOWS_EXPORT DENSITY_FORCE_INLINE DENSITY_KERNEL_DECODE_STATE density_
     state->parameters = parameters;
     density_byte resetDictionaryCycleShift = state->parameters.as_bytes[0];
     if (resetDictionaryCycleShift)
-        state->resetCycle = (uint_fast64_t) (1 << resetDictionaryCycleShift) - 1;
+        state->resetCycle = ((uint_fast64_t) 1 << resetDictionaryCycleShift) - 1;
 
     state->endDataOverhead = endDataOverhead;
 


### PR DESCRIPTION
They are all the same issue; 1 is left shifted as an int then the
result is cast to a uint_fast64_t instead of the shift being performed
on the 64-bit value.